### PR TITLE
🐞 CORS patch fix for all Magento versions

### DIFF
--- a/magento/patches/cors.patch
+++ b/magento/patches/cors.patch
@@ -1,9 +1,11 @@
 diff --git a/phpserver/router.php b/phpserver/router.php
-index 06c23ecd..3946c2de 100644
+index 06c23ecd..628193f5 100644
 --- a/phpserver/router.php
 +++ b/phpserver/router.php
-@@ -1,4 +1,12 @@
- <?php
+@@ -14,6 +14,15 @@
+  * example usage: php -S 127.0.0.41:8082 -t ./pub/ ./router.php
+  */
+ 
 +header('Access-Control-Allow-Origin: *');
 +header('Access-Control-Allow-Methods: *');
 +header('Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization');
@@ -12,6 +14,7 @@ index 06c23ecd..3946c2de 100644
 +    http_response_code(200);
 +    exit;
 +}
++
  /**
-  * Copyright © Magento, Inc. All rights reserved.
-  * See COPYING.txt for license details.
+  * Set it to true to enable debug mode
+  */


### PR DESCRIPTION
Because it fails on older Magento versions because of the copyright is different there, see: https://github.com/michielgerritsen/magento2-extension-integration-test/runs/1259130494?check_suite_focus=true