### PR TITLE
📇 Use Magerun2 for indexing

### DIFF
--- a/magento/Dockerfile
+++ b/magento/Dockerfile
@@ -50,7 +50,7 @@ RUN apt update --fix-missing && \
     php bin/magento setup:di:compile && \
     magerun2 config:store:set catalog/frontend/flat_catalog_category 1 && \
     magerun2 config:store:set catalog/frontend/flat_catalog_product 1 && \
-    php bin/magento indexer:reindex && \
+    magerun2 indexer:reindex && \
     mkdir -p extensions && \
 #    if (( $(php -r 'echo version_compare(PHP_VERSION, "7.2", "ge") && version_compare(PHP_VERSION, "7.4", "lt") ? "true" : "false";') = "true" )); then composer require reach-digital/magento2-test-framework; fi && \
     composer config repositories.dev-extensions path extensions/*


### PR DESCRIPTION
Because `php bin/magento indexer:reindex` somehow doesn't reindex the flat tables.