### PR TITLE
Apply security patches, use mysql over mariadb

### DIFF
--- a/magento/Dockerfile-2.3
+++ b/magento/Dockerfile-2.3
@@ -11,6 +11,9 @@ ENV FLAT_TABLES=false
 
 COPY patches/vertex-compilation-issue.patch vertex-compilation-issue.patch
 COPY patches/79e90baca6442c0fb3627dd1fa1b083c8df4fa01.patch 79e90baca6442c0fb3627dd1fa1b083c8df4fa01.patch
+COPY patches/APSB22-12/MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch
+COPY patches/APSB22-12/MDVA-43443_EE_2.3.4_COMPOSER_v1.patch MDVA-43443_EE_2.3.4_COMPOSER_v1.patch
+COPY patches/APSB22-12/MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch
 
 RUN apt update --fix-missing && \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -18,10 +21,14 @@ RUN apt update --fix-missing && \
     curl -L https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
     echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list && \
     apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8 && \
-    add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://mirror.zol.co.zw/mariadb/repo/10.4/debian stretch main' && \
+    wget https://repo.mysql.com//mysql-apt-config_0.8.18-1_all.deb && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
+    dpkg -i mysql-apt-config_0.8.18-1_all.deb && \
     apt update && \
-    apt install -y elasticsearch mariadb-server mariadb-client && \
+    echo "[mysqld]\ndefault-authentication-plugin=mysql_native_password" > ~/.my.cnf && \
+    apt install -y elasticsearch mysql-server mysql-client && \
     rm -rf /var/lib/apt/lists/* && \
+    sed -i "s/.*bind-address.*/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
     echo 'memory_limit = 4G' >> /usr/local/etc/php/conf.d/memory-limit-php.ini && \
     echo 'max_execution_time = 300' >> /usr/local/etc/php/conf.d/memory-limit-php.ini && \
     rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
@@ -48,6 +55,9 @@ RUN apt update --fix-missing && \
     php bin/magento setup:install --backend-frontname=admin --session-save=db --db-host=127.0.0.1 --db-name=magento --db-user=magento --db-password=password --base-url=http://localhost --timezone=Europe/Amsterdam --currency=EUR --admin-user=exampleuser --admin-password=examplepassword123 --admin-email=user@example.com --admin-firstname=Example --admin-lastname=Example --use-rewrites=1 --use-sample-data && \
     php bin/magento deploy:mode:set developer && \
     if (( $(php -r 'echo substr(getenv("MAGENTO_VERSION"), 0, 5) == "2.3.3" ? "true" : "false";') = "true" )); then echo "applying vertex-compilation-issue.patch"; git apply vertex-compilation-issue.patch; fi && \
+    if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.3.3", ">") ? "true" : "false";') = "true" )); then echo "applying MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch"; git apply MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch; fi && \
+    if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.3.3-p1", ">=") && version_compare(getenv("MAGENTO_VERSION"), "2.3.4", "<=") ? "true" : "false";') = "true" )); then echo "applying MDVA-43443_EE_2.3.4_COMPOSER_v1.patch"; git apply MDVA-43443_EE_2.3.4_COMPOSER_v1.patch; fi && \
+    if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.3.4-p2", ">=") ? "true" : "false";') = "true" )); then echo "applying MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch"; git apply MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch; fi && \
     if [ "${SAMPLE_DATA}" = "true" ]; then php bin/magento sampledata:deploy; fi && \
     if [ "${SAMPLE_DATA}" = "true" ]; then php bin/magento setup:upgrade; fi && \
     php bin/magento setup:di:compile && \

--- a/magento/Dockerfile-2.4
+++ b/magento/Dockerfile-2.4
@@ -12,6 +12,9 @@ ENV FLAT_TABLES=false
 COPY patches/vertex-compilation-issue.patch vertex-compilation-issue.patch
 COPY patches/79e90baca6442c0fb3627dd1fa1b083c8df4fa01.patch 79e90baca6442c0fb3627dd1fa1b083c8df4fa01.patch
 COPY patches/pr-33803.diff pr-33803.diff
+COPY patches/APSB22-12/MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch
+COPY patches/APSB22-12/MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch
+COPY patches/APSB22-12/MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch
 
 RUN apt update --fix-missing && \
     export DEBIAN_FRONTEND=noninteractive && \
@@ -19,6 +22,7 @@ RUN apt update --fix-missing && \
     curl -L https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - && \
     echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list && \
     wget https://repo.mysql.com//mysql-apt-config_0.8.18-1_all.deb && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
     dpkg -i mysql-apt-config_0.8.18-1_all.deb && \
     apt update && \
     echo "[mysqld]\ndefault-authentication-plugin=mysql_native_password" > ~/.my.cnf && \
@@ -48,6 +52,9 @@ RUN apt update --fix-missing && \
     mysql -u root -e "GRANT ALL PRIVILEGES ON * . * TO 'magento'@'%';" && \
     mysql -u root -e "GRANT ALL PRIVILEGES ON * . * TO 'magento-test'@'%';" && \
     sleep 5 && \
+    echo "applying MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch"; git apply MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch && \
+    if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.4.2-p2", "<=") ? "true" : "false";') = "true" )); then echo "applying MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch"; git apply MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch; fi && \
+    if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.4.3", ">=") ? "true" : "false";') = "true" )); then echo "applying MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch"; git apply MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch; fi && \
     php bin/magento setup:install --backend-frontname=admin --session-save=db --db-host=127.0.0.1 --db-name=magento --db-user=magento --db-password=password --base-url=http://localhost --timezone=Europe/Amsterdam --currency=EUR --admin-user=exampleuser --admin-password=examplepassword123 --admin-email=user@example.com --admin-firstname=Example --admin-lastname=Example --use-rewrites=1 --use-sample-data && \
     php bin/magento deploy:mode:set developer && \
     if [ "${SAMPLE_DATA}" = "true" ]; then php bin/magento sampledata:deploy; fi && \

--- a/magento/patches/APSB22-12/MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch
+++ b/magento/patches/APSB22-12/MDVA-43395_EE_2.4.3-p1_COMPOSER_v1.patch
@@ -1,0 +1,33 @@
+diff --git a/vendor/magento/module-email/Model/Template/Filter.php b/vendor/magento/module-email/Model/Template/Filter.php
+index 1a7c3683820a..586cb485ee1f 100644
+--- a/vendor/magento/module-email/Model/Template/Filter.php
++++ b/vendor/magento/module-email/Model/Template/Filter.php
+@@ -618,6 +618,12 @@ public function transDirective($construction)
+         }
+ 
+         $text = __($text, $params)->render();
++
++        $pattern = '/{{.*?}}/';
++        do {
++            $text = preg_replace($pattern, '', (string)$text);
++        } while (preg_match($pattern, $text));
++
+         return $this->applyModifiers($text, $modifiers);
+     }
+ 
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+index f2fe398c3848..78034d70ba51 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+@@ -55,6 +55,11 @@ public function process(array $construction, Template $filter, array $templateVa
+             $result = $this->filterApplier->applyFromRawParam($construction['filters'], $result);
+         }
+ 
++        $pattern = '/{{.*?}}/';
++        do {
++            $result = preg_replace($pattern, '', (string)$result);
++        } while (preg_match($pattern, $result));
++
+         return $result;
+     }
+ 

--- a/magento/patches/APSB22-12/MDVA-43443_EE_2.3.4_COMPOSER_v1.patch
+++ b/magento/patches/APSB22-12/MDVA-43443_EE_2.3.4_COMPOSER_v1.patch
@@ -1,0 +1,363 @@
+diff --git a/vendor/magento/module-email/Model/Template/Filter.php b/vendor/magento/module-email/Model/Template/Filter.php
+index ccb04937675..5cc50bc4507 100644
+--- a/vendor/magento/module-email/Model/Template/Filter.php
++++ b/vendor/magento/module-email/Model/Template/Filter.php
+@@ -379,14 +379,14 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * Retrieve Block html directive
+-     *
+      * @param array $construction
++     *
+      * @return string
++     *
+      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+      * @SuppressWarnings(PHPMD.NPathComplexity)
+      */
+-    public function blockDirective($construction)
++    private function resolveBlockDirective($construction)
+     {
+         $skipParams = ['class', 'id', 'output'];
+         $blockParameters = $this->getParameters($construction[2]);
+@@ -427,12 +427,26 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * Retrieve layout html directive
++     * Retrieve Block html directive
+      *
++     * @param array $construction
++     * @return string
++     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
++     * @SuppressWarnings(PHPMD.NPathComplexity)
++     */
++    public function blockDirective($construction)
++    {
++        $result = $this->resolveBlockDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
++    /**
+      * @param string[] $construction
++     *
+      * @return string
+      */
+-    public function layoutDirective($construction)
++    private function resolveLayoutDirective($construction)
+     {
+         $this->_directiveParams = $this->getParameters($construction[2]);
+         if (!isset($this->_directiveParams['area'])) {
+@@ -448,6 +462,19 @@ class Filter extends \Magento\Framework\Filter\Template
+         }
+     }
+
++    /**
++     * Retrieve layout html directive
++     *
++     * @param string[] $construction
++     * @return string
++     */
++    public function layoutDirective($construction)
++    {
++        $result = $this->resolveLayoutDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
+     /**
+      * Retrieve layout html directive callback
+      *
+@@ -515,7 +542,7 @@ class Filter extends \Magento\Framework\Filter\Template
+     {
+         $params = $this->getParameters($construction[2]);
+         $url = $this->_assetRepo->getUrlWithParams($params['url'], $params);
+-        return $url;
++        return $this->sanitizeValue($url);
+     }
+
+     /**
+@@ -528,8 +555,11 @@ class Filter extends \Magento\Framework\Filter\Template
+     {
+         // phpcs:disable Magento2.Functions.DiscouragedFunction
+         $params = $this->getParameters(html_entity_decode($construction[2], ENT_QUOTES));
+-        return $this->_storeManager->getStore()
+-            ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . $params['url'];
++        return $this->sanitizeValue(
++            $this->_storeManager->getStore()
++                ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . $params['url']
++        );
++
+     }
+
+     /**
+@@ -567,7 +597,7 @@ class Filter extends \Magento\Framework\Filter\Template
+             unset($params['url']);
+         }
+
+-        return $this->urlModel->getUrl($path, $params);
++        return $this->sanitizeValue($this->urlModel->getUrl($path, $params));
+     }
+
+     /**
+@@ -606,12 +636,7 @@ class Filter extends \Magento\Framework\Filter\Template
+
+         $text = __($text, $params)->render();
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $text = preg_replace($pattern, '', (string)$text);
+-        } while (preg_match($pattern, $text));
+-
+-        return $this->applyModifiers($text, $modifiers);
++        return $this->applyModifiers($this->sanitizeValue($text), $modifiers);
+     }
+
+     /**
+@@ -655,7 +680,10 @@ class Filter extends \Magento\Framework\Filter\Template
+             $construction[2] . ($construction['filters'] ?? ''),
+             'escape'
+         );
+-        return $this->applyModifiers($this->getVariable($directive, ''), $modifiers);
++
++        $result = $this->sanitizeValue($this->getVariable($directive, ''));
++
++        return $this->applyModifiers($result, $modifiers);
+     }
+
+     /**
+@@ -736,20 +764,11 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * HTTP Protocol directive
+-     *
+-     * Usage:
+-     *
+-     *     {{protocol}} - current protocol http or https
+-     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
+-     *     {{protocol http="http://url" https="https://url"}}
+-     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
+-     *
+      * @param string[] $construction
+      * @throws \Magento\Framework\Exception\MailException
+      * @return string
+      */
+-    public function protocolDirective($construction)
++    private function resolveProtocolDirective($construction)
+     {
+         $params = $this->getParameters($construction[2]);
+         $store = null;
+@@ -776,6 +795,27 @@ class Filter extends \Magento\Framework\Filter\Template
+         return $protocol;
+     }
+
++    /**
++     * HTTP Protocol directive
++     *
++     * Usage:
++     *
++     *     {{protocol}} - current protocol http or https
++     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
++     *     {{protocol http="http://url" https="https://url"}}
++     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
++     *
++     * @param string[] $construction
++     * @throws \Magento\Framework\Exception\MailException
++     * @return string
++     */
++    public function protocolDirective($construction)
++    {
++        return $this->sanitizeValue(
++            $this->resolveProtocolDirective($construction)
++        );
++    }
++
+     /**
+      * Store config directive
+      *
+@@ -794,7 +834,7 @@ class Filter extends \Magento\Framework\Filter\Template
+                 $storeId
+             );
+         }
+-        return $configValue;
++        return $this->sanitizeValue($configValue);
+     }
+
+     /**
+@@ -835,7 +875,8 @@ class Filter extends \Magento\Framework\Filter\Template
+                 $customVarValue = $value;
+             }
+         }
+-        return $customVarValue;
++
++        return $this->sanitizeValue($customVarValue);
+     }
+
+     /**
+@@ -1062,4 +1103,14 @@ class Filter extends \Magento\Framework\Filter\Template
+         }
+         return $value;
+     }
++
++    /**
++     * @param string $value
++     *
++     * @return string|bool
++     */
++    private function sanitizeValue($value)
++    {
++        return is_bool($value) ? $value : str_replace(['{', '}'], '', (string) $value);
++    }
+ }
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+index f557f7465b5..83345acd6e5 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+@@ -32,9 +32,13 @@ class DependDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             // If template processing
+@@ -48,6 +52,16 @@ class DependDirective implements DirectiveProcessorInterface
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+index 2b51185b1b5..41cd58118fd 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+@@ -36,14 +36,13 @@ class ForDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * Filter the string as template.
+-     *
+      * @param array $construction
+      * @param Template $filter
+      * @param array $templateVariables
++     *
+      * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (!$this->isValidLoop($construction)) {
+             return $construction[0];
+@@ -67,6 +66,16 @@ class ForDirective implements DirectiveProcessorInterface
+         return $construction[0];
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * Check if the matched construction is valid.
+      *
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+index 7fedc7946f2..469dae71d06 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+@@ -32,9 +32,13 @@ class IfDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             return $construction[0];
+@@ -50,6 +54,16 @@ class IfDirective implements DirectiveProcessorInterface
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+index 9f4b30d0c96..b9280aec283 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+@@ -68,7 +68,7 @@ class SimpleDirective implements DirectiveProcessorInterface
+                 ->get($construction['directiveName']);
+         } catch (\InvalidArgumentException $e) {
+             // This directive doesn't have a SimpleProcessor
+-            return $construction[0];
++            return '';
+         }
+
+         $parameters = $this->extractParameters($construction, $filter, $templateVariables);
+@@ -79,6 +79,8 @@ class SimpleDirective implements DirectiveProcessorInterface
+             !empty($construction['content']) ? $filter->filter($construction['content']) : null
+         );
+
++        $value = str_replace(['{', '}'], '', (string) $value);
++
+         $value = $this->filterApplier->applyFromRawParam(
+             $construction['filters'] ?? '',
+             $value,
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+index 78034d70ba5..a7d6790acc7 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+@@ -55,10 +55,7 @@ class VarDirective implements DirectiveProcessorInterface
+             $result = $this->filterApplier->applyFromRawParam($construction['filters'], $result);
+         }
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $result = preg_replace($pattern, '', (string)$result);
+-        } while (preg_match($pattern, $result));
++        $result = str_replace(['{', '}'], '', (string) $result);
+
+         return $result;
+     }

--- a/magento/patches/APSB22-12/MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch
+++ b/magento/patches/APSB22-12/MDVA-43443_EE_2.4.2-p2_COMPOSER_v1.patch
@@ -1,0 +1,367 @@
+diff --git a/vendor/magento/module-email/Model/Template/Filter.php b/vendor/magento/module-email/Model/Template/Filter.php
+index 88b204307f2..52b1018e1af 100644
+--- a/vendor/magento/module-email/Model/Template/Filter.php
++++ b/vendor/magento/module-email/Model/Template/Filter.php
+@@ -379,14 +379,14 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * Retrieve Block html directive
+-     *
+      * @param array $construction
++     *
+      * @return string
++     *
+      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+      * @SuppressWarnings(PHPMD.NPathComplexity)
+      */
+-    public function blockDirective($construction)
++    private function resolveBlockDirective($construction)
+     {
+         $skipParams = ['class', 'id', 'output'];
+         $blockParameters = $this->getParameters($construction[2]);
+@@ -427,12 +427,26 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * Retrieve layout html directive
++     * Retrieve Block html directive
+      *
++     * @param array $construction
++     * @return string
++     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
++     * @SuppressWarnings(PHPMD.NPathComplexity)
++     */
++    public function blockDirective($construction)
++    {
++        $result = $this->resolveBlockDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
++    /**
+      * @param string[] $construction
++     *
+      * @return string
+      */
+-    public function layoutDirective($construction)
++    private function resolveLayoutDirective($construction)
+     {
+         $this->_directiveParams = $this->getParameters($construction[2]);
+         if (!isset($this->_directiveParams['area'])) {
+@@ -448,6 +462,19 @@ class Filter extends \Magento\Framework\Filter\Template
+         }
+     }
+
++    /**
++     * Retrieve layout html directive
++     *
++     * @param string[] $construction
++     * @return string
++     */
++    public function layoutDirective($construction)
++    {
++        $result = $this->resolveLayoutDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
+     /**
+      * Retrieve layout html directive callback
+      *
+@@ -515,7 +542,7 @@ class Filter extends \Magento\Framework\Filter\Template
+     {
+         $params = $this->getParameters($construction[2]);
+         $url = $this->_assetRepo->getUrlWithParams($params['url'], $params);
+-        return $url;
++        return $this->sanitizeValue($url);
+     }
+
+     /**
+@@ -528,8 +555,11 @@ class Filter extends \Magento\Framework\Filter\Template
+     {
+         // phpcs:disable Magento2.Functions.DiscouragedFunction
+         $params = $this->getParameters(html_entity_decode($construction[2], ENT_QUOTES));
+-        return $this->_storeManager->getStore()
+-            ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . $params['url'];
++        return $this->sanitizeValue(
++            $this->_storeManager->getStore()
++                ->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . $params['url']
++        );
++
+     }
+
+     /**
+@@ -567,7 +597,7 @@ class Filter extends \Magento\Framework\Filter\Template
+             unset($params['url']);
+         }
+
+-        return $this->urlModel->getUrl($path, $params);
++        return $this->sanitizeValue($this->urlModel->getUrl($path, $params));
+     }
+
+     /**
+@@ -606,12 +636,7 @@ class Filter extends \Magento\Framework\Filter\Template
+
+         $text = __($text, $params)->render();
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $text = preg_replace($pattern, '', (string)$text);
+-        } while (preg_match($pattern, $text));
+-
+-        return $this->applyModifiers($text, $modifiers);
++        return $this->applyModifiers($this->sanitizeValue($text), $modifiers);
+     }
+
+     /**
+@@ -655,7 +680,10 @@ class Filter extends \Magento\Framework\Filter\Template
+             $construction[2] . ($construction['filters'] ?? ''),
+             'escape'
+         );
+-        return $this->applyModifiers($this->getVariable($directive, ''), $modifiers);
++
++        $result = $this->sanitizeValue($this->getVariable($directive, ''));
++
++        return $this->applyModifiers($result, $modifiers);
+     }
+
+     /**
+@@ -736,21 +764,14 @@ class Filter extends \Magento\Framework\Filter\Template
+     }
+
+     /**
+-     * HTTP Protocol directive
+-     *
+-     * Usage:
+-     *
+-     *     {{protocol}} - current protocol http or https
+-     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
+-     *     {{protocol http="http://url" https="https://url"}}
+-     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
+-     *
+      * @param string[] $construction
++     *
+      * @return string
++     *
+      * @throws MailException
+      * @throws NoSuchEntityException
+      */
+-    public function protocolDirective($construction)
++    private function resolveProtocolDirective($construction)
+     {
+         $params = $this->getParameters($construction[2]);
+
+@@ -781,6 +802,28 @@ class Filter extends \Magento\Framework\Filter\Template
+         return $protocol;
+     }
+
++    /**
++     * HTTP Protocol directive
++     *
++     * Usage:
++     *
++     *     {{protocol}} - current protocol http or https
++     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
++     *     {{protocol http="http://url" https="https://url"}}
++     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
++     *
++     * @param string[] $construction
++     * @return string
++     * @throws MailException
++     * @throws NoSuchEntityException
++     */
++    public function protocolDirective($construction)
++    {
++        return $this->sanitizeValue(
++            $this->resolveProtocolDirective($construction)
++        );
++    }
++
+     /**
+      * Validate protocol directive HTTP parameters.
+      *
+@@ -830,7 +873,7 @@ class Filter extends \Magento\Framework\Filter\Template
+                 $storeId
+             );
+         }
+-        return $configValue;
++        return $this->sanitizeValue($configValue);
+     }
+
+     /**
+@@ -871,7 +914,8 @@ class Filter extends \Magento\Framework\Filter\Template
+                 $customVarValue = $value;
+             }
+         }
+-        return $customVarValue;
++
++        return $this->sanitizeValue($customVarValue);
+     }
+
+     /**
+@@ -1098,4 +1142,14 @@ class Filter extends \Magento\Framework\Filter\Template
+         }
+         return $value;
+     }
++
++    /**
++     * @param string $value
++     *
++     * @return string|bool
++     */
++    private function sanitizeValue($value)
++    {
++        return is_bool($value) ? $value : str_replace(['{', '}'], '', (string) $value);
++    }
+ }
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+index f557f7465b5..83345acd6e5 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+@@ -32,9 +32,13 @@ class DependDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             // If template processing
+@@ -48,6 +52,16 @@ class DependDirective implements DirectiveProcessorInterface
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+index 2b51185b1b5..41cd58118fd 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+@@ -36,14 +36,13 @@ class ForDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * Filter the string as template.
+-     *
+      * @param array $construction
+      * @param Template $filter
+      * @param array $templateVariables
++     *
+      * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (!$this->isValidLoop($construction)) {
+             return $construction[0];
+@@ -67,6 +66,16 @@ class ForDirective implements DirectiveProcessorInterface
+         return $construction[0];
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * Check if the matched construction is valid.
+      *
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+index 7fedc7946f2..469dae71d06 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+@@ -32,9 +32,13 @@ class IfDirective implements DirectiveProcessorInterface
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             return $construction[0];
+@@ -50,6 +54,16 @@ class IfDirective implements DirectiveProcessorInterface
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+index 9f4b30d0c96..b9280aec283 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+@@ -68,7 +68,7 @@ class SimpleDirective implements DirectiveProcessorInterface
+                 ->get($construction['directiveName']);
+         } catch (\InvalidArgumentException $e) {
+             // This directive doesn't have a SimpleProcessor
+-            return $construction[0];
++            return '';
+         }
+
+         $parameters = $this->extractParameters($construction, $filter, $templateVariables);
+@@ -79,6 +79,8 @@ class SimpleDirective implements DirectiveProcessorInterface
+             !empty($construction['content']) ? $filter->filter($construction['content']) : null
+         );
+
++        $value = str_replace(['{', '}'], '', (string) $value);
++
+         $value = $this->filterApplier->applyFromRawParam(
+             $construction['filters'] ?? '',
+             $value,
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+index 78034d70ba5..a7d6790acc7 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+@@ -55,10 +55,7 @@ class VarDirective implements DirectiveProcessorInterface
+             $result = $this->filterApplier->applyFromRawParam($construction['filters'], $result);
+         }
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $result = preg_replace($pattern, '', (string)$result);
+-        } while (preg_match($pattern, $result));
++        $result = str_replace(['{', '}'], '', (string) $result);
+
+         return $result;
+     }

--- a/magento/patches/APSB22-12/MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch
+++ b/magento/patches/APSB22-12/MDVA-43443_EE_2.4.3-p1_COMPOSER_v1.patch
@@ -1,0 +1,366 @@
+diff --git a/vendor/magento/module-email/Model/Template/Filter.php b/vendor/magento/module-email/Model/Template/Filter.php
+index 586cb485ee1f..a7f0825cb41f 100644
+--- a/vendor/magento/module-email/Model/Template/Filter.php
++++ b/vendor/magento/module-email/Model/Template/Filter.php
+@@ -392,14 +392,14 @@ public function getStoreId()
+     }
+
+     /**
+-     * Retrieve Block html directive
+-     *
+      * @param array $construction
++     *
+      * @return string
++     *
+      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+      * @SuppressWarnings(PHPMD.NPathComplexity)
+      */
+-    public function blockDirective($construction)
++    private function resolveBlockDirective($construction)
+     {
+         $skipParams = ['class', 'id', 'output'];
+         $blockParameters = $this->getParameters($construction[2]);
+@@ -440,12 +440,26 @@ public function blockDirective($construction)
+     }
+
+     /**
+-     * Retrieve layout html directive
++     * Retrieve Block html directive
+      *
++     * @param array $construction
++     * @return string
++     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
++     * @SuppressWarnings(PHPMD.NPathComplexity)
++     */
++    public function blockDirective($construction)
++    {
++        $result = $this->resolveBlockDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
++    /**
+      * @param string[] $construction
++     *
+      * @return string
+      */
+-    public function layoutDirective($construction)
++    private function resolveLayoutDirective($construction)
+     {
+         $this->_directiveParams = $this->getParameters($construction[2]);
+         if (!isset($this->_directiveParams['area'])) {
+@@ -461,6 +475,19 @@ public function layoutDirective($construction)
+         }
+     }
+
++    /**
++     * Retrieve layout html directive
++     *
++     * @param string[] $construction
++     * @return string
++     */
++    public function layoutDirective($construction)
++    {
++        $result = $this->resolveLayoutDirective($construction);
++
++        return preg_replace("/{{/", "&#123;&#123;", $result);
++    }
++
+     /**
+      * Retrieve layout html directive callback
+      *
+@@ -528,7 +555,7 @@ public function viewDirective($construction)
+     {
+         $params = $this->getParameters($construction[2]);
+         $url = $this->_assetRepo->getUrlWithParams($params['url'], $params);
+-        return $url;
++        return $this->sanitizeValue($url);
+     }
+
+     /**
+@@ -541,8 +568,10 @@ public function mediaDirective($construction)
+     {
+         // phpcs:disable Magento2.Functions.DiscouragedFunction
+         $params = $this->getParameters(html_entity_decode($construction[2], ENT_QUOTES));
+-        return $this->_storeManager->getStore()
+-            ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . $params['url'];
++        return $this->sanitizeValue(
++            $this->_storeManager->getStore()
++                ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . $params['url']
++        );
+     }
+
+     /**
+@@ -580,7 +609,7 @@ public function storeDirective($construction)
+             unset($params['url']);
+         }
+
+-        return $this->urlModel->getUrl($path, $params);
++        return $this->sanitizeValue($this->urlModel->getUrl($path, $params));
+     }
+
+     /**
+@@ -619,12 +648,7 @@ public function transDirective($construction)
+
+         $text = __($text, $params)->render();
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $text = preg_replace($pattern, '', (string)$text);
+-        } while (preg_match($pattern, $text));
+-
+-        return $this->applyModifiers($text, $modifiers);
++        return $this->applyModifiers($this->sanitizeValue($text), $modifiers);
+     }
+
+     /**
+@@ -668,7 +692,10 @@ public function varDirective($construction)
+             $construction[2] . ($construction['filters'] ?? ''),
+             'escape'
+         );
+-        return $this->applyModifiers($this->getVariable($directive, ''), $modifiers);
++
++        $result = $this->sanitizeValue($this->getVariable($directive, ''));
++
++        return $this->applyModifiers($result, $modifiers);
+     }
+
+     /**
+@@ -749,21 +776,14 @@ public function modifierEscape($value, $type = 'html')
+     }
+
+     /**
+-     * HTTP Protocol directive
+-     *
+-     * Usage:
+-     *
+-     *     {{protocol}} - current protocol http or https
+-     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
+-     *     {{protocol http="http://url" https="https://url"}}
+-     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
+-     *
+      * @param string[] $construction
++     *
+      * @return string
++     *
+      * @throws MailException
+      * @throws NoSuchEntityException
+      */
+-    public function protocolDirective($construction)
++    private function resolveProtocolDirective($construction)
+     {
+         $params = $this->getParameters($construction[2]);
+
+@@ -794,6 +814,28 @@ public function protocolDirective($construction)
+         return $protocol;
+     }
+
++    /**
++     * HTTP Protocol directive
++     *
++     * Usage:
++     *
++     *     {{protocol}} - current protocol http or https
++     *     {{protocol url="www.domain.com/"}} - domain URL with current protocol
++     *     {{protocol http="http://url" https="https://url"}}
++     *     {{protocol store="1"}} - Optional parameter which gets protocol from provide store based on store ID or code
++     *
++     * @param string[] $construction
++     * @return string
++     * @throws MailException
++     * @throws NoSuchEntityException
++     */
++    public function protocolDirective($construction)
++    {
++        return $this->sanitizeValue(
++            $this->resolveProtocolDirective($construction)
++        );
++    }
++
+     /**
+      * Validate protocol directive HTTP parameters.
+      *
+@@ -843,7 +885,7 @@ public function configDirective($construction)
+                 $storeId
+             );
+         }
+-        return $configValue;
++        return $this->sanitizeValue($configValue);
+     }
+
+     /**
+@@ -884,7 +926,8 @@ public function customvarDirective($construction)
+                 $customVarValue = $value;
+             }
+         }
+-        return $customVarValue;
++
++        return $this->sanitizeValue($customVarValue);
+     }
+
+     /**
+@@ -1113,4 +1156,14 @@ public function filter($value)
+         }
+         return $value;
+     }
++
++    /**
++     * @param string $value
++     *
++     * @return string|bool
++     */
++    private function sanitizeValue($value)
++    {
++        return is_bool($value) ? $value : str_replace(['{', '}'], '', (string) $value);
++    }
+ }
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+index f557f7465b5f..83345acd6e5b 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/DependDirective.php
+@@ -32,9 +32,13 @@ public function __construct(
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             // If template processing
+@@ -48,6 +52,16 @@ public function process(array $construction, Template $filter, array $templateVa
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+index 2b51185b1b5f..41cd58118fd6 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/ForDirective.php
+@@ -36,14 +36,13 @@ public function __construct(
+     }
+
+     /**
+-     * Filter the string as template.
+-     *
+      * @param array $construction
+      * @param Template $filter
+      * @param array $templateVariables
++     *
+      * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (!$this->isValidLoop($construction)) {
+             return $construction[0];
+@@ -67,6 +66,16 @@ public function process(array $construction, Template $filter, array $templateVa
+         return $construction[0];
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * Check if the matched construction is valid.
+      *
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+index 7fedc7946f21..469dae71d068 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/IfDirective.php
+@@ -32,9 +32,13 @@ public function __construct(
+     }
+
+     /**
+-     * @inheritdoc
++     * @param array $construction
++     * @param Template $filter
++     * @param array $templateVariables
++     *
++     * @return string
+      */
+-    public function process(array $construction, Template $filter, array $templateVariables): string
++    private function resolve(array $construction, Template $filter, array $templateVariables): string
+     {
+         if (empty($templateVariables)) {
+             return $construction[0];
+@@ -50,6 +54,16 @@ public function process(array $construction, Template $filter, array $templateVa
+         }
+     }
+
++    /**
++     * @inheritdoc
++     */
++    public function process(array $construction, Template $filter, array $templateVariables): string
++    {
++        $result = $this->resolve($construction, $filter, $templateVariables);
++
++        return str_replace(['{', '}'], '', (string) $result);
++    }
++
+     /**
+      * @inheritdoc
+      */
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+index 9f4b30d0c96c..b9280aec2833 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/SimpleDirective.php
+@@ -68,7 +68,7 @@ public function process(array $construction, Template $filter, array $templateVa
+                 ->get($construction['directiveName']);
+         } catch (\InvalidArgumentException $e) {
+             // This directive doesn't have a SimpleProcessor
+-            return $construction[0];
++            return '';
+         }
+
+         $parameters = $this->extractParameters($construction, $filter, $templateVariables);
+@@ -79,6 +79,8 @@ public function process(array $construction, Template $filter, array $templateVa
+             !empty($construction['content']) ? $filter->filter($construction['content']) : null
+         );
+
++        $value = str_replace(['{', '}'], '', (string) $value);
++
+         $value = $this->filterApplier->applyFromRawParam(
+             $construction['filters'] ?? '',
+             $value,
+diff --git a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+index 78034d70ba51..a7d6790acc79 100644
+--- a/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
++++ b/vendor/magento/framework/Filter/DirectiveProcessor/VarDirective.php
+@@ -55,10 +55,7 @@ public function process(array $construction, Template $filter, array $templateVa
+             $result = $this->filterApplier->applyFromRawParam($construction['filters'], $result);
+         }
+
+-        $pattern = '/{{.*?}}/';
+-        do {
+-            $result = preg_replace($pattern, '', (string)$result);
+-        } while (preg_match($pattern, $result));
++        $result = str_replace(['{', '}'], '', (string) $result);
+
+         return $result;
+     }


### PR DESCRIPTION
Apply the appropriate patches described by
https://helpx.adobe.com/security/products/magento/apsb22-12.html

Also opted to use mysql instead of mariaDB since it tries to install a version of mariaDB that is too recent, attempting to use a lower version results in dependency hell.