### PR TITLE
Add Store header to Allowed Headers

### DIFF
--- a/magento/patches/cors.patch
+++ b/magento/patches/cors.patch
@@ -8,7 +8,7 @@ index 06c23ecd..628193f5 100644
  
 +header('Access-Control-Allow-Origin: *');
 +header('Access-Control-Allow-Methods: *');
-+header('Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization');
++header('Access-Control-Allow-Headers: DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Authorization,Store');
 +
 +if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 +    http_response_code(200);


### PR DESCRIPTION
This is needed to make the GraphQL requests to the correct store.

Also see this in the Magento docs:
https://devdocs.magento.com/guides/v2.4/graphql/send-request.html#:~:text=The%20store%20view%20code%20on%20which%20to%20perform%20the%20request.%20The%20value%20can%20be%20default%20or%20the%20code%20that%20is%20defined%20when%20a%20store%20view%20is%20created