### PR TITLE
Fix Magento 2.4.4 Compilation issues on PHP 8.1

### DIFF
--- a/.github/workflows/magento-2.4.yml
+++ b/.github/workflows/magento-2.4.yml
@@ -88,56 +88,54 @@ jobs:
           - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.5-p1, SAMPLE_DATA: true }
           - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.5, SAMPLE_DATA: false }
           - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.5, SAMPLE_DATA: true }
-          # 2.4.4 + 8.1 is disabled due to this bug:
-          # https://github.com/magento/magento2/issues/35292
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p11, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p10, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p9, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p8, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p7, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p6, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p5, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p4, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p3, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p2, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4-p1, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: true }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: false }
-#          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: true }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: false }
+          - { PHP_VERSION: php81-fpm, MAGENTO_VERSION: 2.4.4, SAMPLE_DATA: true }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.3-p2, SAMPLE_DATA: false }
           - { PHP_VERSION: php74-fpm, MAGENTO_VERSION: 2.4.3-p2, SAMPLE_DATA: true }
           - { PHP_VERSION: php73-fpm, MAGENTO_VERSION: 2.4.3-p1, SAMPLE_DATA: false }

--- a/magento/Dockerfile-2.4
+++ b/magento/Dockerfile-2.4
@@ -29,6 +29,8 @@ RUN ./start-services && \
     if (( $(php -r 'echo version_compare(getenv("MAGENTO_VERSION"), "2.4.2", "<=") ? "true" : "false";') = "true" )); then echo "Using Composer version 1 so skipping allow-plugins"; else php scripts/allow-composer-plugins.php rm scripts/allow-composer-plugins.php; fi && \
     composer config --unset repositories.0 && \
     composer config repositories.fooman composer https://repo-magento-mirror.fooman.co.nz/ && \
+    if [ "$MAGENTO_VERSION" = "2.4.4" ]; then composer require "magento/security-package:1.1.3-p1 as 1.1.3" --no-update; fi && \
+    if [ "$MAGENTO_VERSION" = "2.4.4" ]; then composer require "magento/inventory-metapackage:1.2.4-p1 as 1.2.4" --no-update; fi && \
     ./retry "composer install" && \
     php scripts/patch-AC2855.php && \
     php scripts/downgrade-monolog.php && \

--- a/magento/Dockerfile-2.4
+++ b/magento/Dockerfile-2.4
@@ -16,6 +16,7 @@ COPY scripts/apply-2.4-patches.php scripts/apply-2.4-patches.php
 COPY scripts/downgrade-monolog.php scripts/downgrade-monolog.php
 COPY scripts/allow-composer-plugins.php scripts/allow-composer-plugins.php
 COPY scripts/remove-paypal-braintree.php scripts/remove-paypal-braintree.php
+COPY scripts/patch-AC2855.php scripts/patch-AC2855.php
 COPY templates/memory-limit-php.ini /usr/local/etc/php/conf.d/memory-limit-php.ini
 
 RUN ./start-services && \
@@ -29,6 +30,7 @@ RUN ./start-services && \
     composer config --unset repositories.0 && \
     composer config repositories.fooman composer https://repo-magento-mirror.fooman.co.nz/ && \
     ./retry "composer install" && \
+    php scripts/patch-AC2855.php && \
     php scripts/downgrade-monolog.php && \
     php scripts/remove-paypal-braintree.php && \
     if [ -f "/data/vendor/magento/module-inventory-catalog/etc/communication.xml" ]; then sed -i 's/is_synchronous="false"//g' /data/vendor/magento/module-inventory-catalog/etc/communication.xml; fi && \

--- a/magento/patches/AC2855.patch
+++ b/magento/patches/AC2855.patch
@@ -1,0 +1,61 @@
+diff --git a/vendor/magento/framework/Code/Generator/EntityAbstract.php b/vendor/magento/framework/Code/Generator/EntityAbstract.php
+index 35a0bff..10fd3f7 100644
+--- a/vendor/magento/framework/Code/Generator/EntityAbstract.php
++++ b/vendor/magento/framework/Code/Generator/EntityAbstract.php
+@@ -10,6 +10,8 @@ use Magento\Framework\GetParameterClassTrait;
+ 
+ /**
+  * Abstract entity
++ *
++ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+  */
+ abstract class EntityAbstract
+ {
+@@ -18,7 +20,7 @@ abstract class EntityAbstract
+     /**
+      * Entity type abstract
+      */
+-    const ENTITY_TYPE = 'abstract';
++    public const ENTITY_TYPE = 'abstract';
+ 
+     /**
+      * @var string[]
+@@ -332,14 +334,22 @@ abstract class EntityAbstract
+         /** @var string|null $typeName */
+         $typeName = null;
+         $parameterType = $parameter->getType();
+-        if ($parameterType->getName() === 'array') {
++
++        if ($parameterType instanceof \ReflectionUnionType) {
++            $parameterType = $parameterType->getTypes();
++            $parameterType = implode('|', $parameterType);
++        } else {
++            $parameterType = $parameterType->getName();
++        }
++
++        if ($parameterType === 'array') {
+             $typeName = 'array';
+         } elseif ($parameterClass = $this->getParameterClass($parameter)) {
+             $typeName = $this->_getFullyQualifiedClassName($parameterClass->getName());
+-        } elseif ($parameterType->getName() === 'callable') {
++        } elseif ($parameterType === 'callable') {
+             $typeName = 'callable';
+         } else {
+-            $typeName = $parameterType->getName();
++            $typeName = $parameterType;
+         }
+ 
+         if ($parameter->allowsNull()) {
+diff --git a/vendor/magento/framework/Interception/Code/Generator/Interceptor.php b/vendor/magento/framework/Interception/Code/Generator/Interceptor.php
+index 43e9d97..c363f80 100644
+--- a/vendor/magento/framework/Interception/Code/Generator/Interceptor.php
++++ b/vendor/magento/framework/Interception/Code/Generator/Interceptor.php
+@@ -72,7 +72,7 @@ class Interceptor extends EntityAbstract
+         $reflectionClass = new \ReflectionClass($this->getSourceClassName());
+         $publicMethods = $reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+         foreach ($publicMethods as $method) {
+-            if ($this->isInterceptedMethod($method)) {
++            if (!$method->isInternal() && $this->isInterceptedMethod($method)) {
+                 $methods[] = $this->_getMethodInfo($method);
+             }
+         }

--- a/magento/scripts/patch-AC2855.php
+++ b/magento/scripts/patch-AC2855.php
@@ -3,9 +3,8 @@
 
 $version = getenv('MAGENTO_VERSION');
 $is244 = substr($version, 0, 5) == '2.4.4';
-$patchLevel = (int)substr($version, 7);
 
-if (!$is244 || $patchLevel > 100) {
+if (!$is244) {
     echo 'AC2855 Breaking bug does not exist in this version' . PHP_EOL;
     exit(0);
 }
@@ -19,3 +18,5 @@ if ($code !== 0) {
     echo implode(PHP_EOL, $output);
     exit($code);
 }
+
+echo 'Applied patch AC2855' . PHP_EOL;

--- a/magento/scripts/patch-AC2855.php
+++ b/magento/scripts/patch-AC2855.php
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+$version = getenv('MAGENTO_VERSION');
+$is244 = substr($version, 0, 5) == '2.4.4';
+$patchLevel = (int)substr($version, 7);
+
+if (!$is244 || $patchLevel > 100) {
+    echo 'AC2855 Breaking bug does not exist in this version' . PHP_EOL;
+    exit(0);
+}
+
+$output = null;
+$code = null;
+exec('cd /data && patch -p1 < patches/AC2855.patch', $output, $code);
+
+if ($code !== 0) {
+    echo 'Error applying patch for AC2855' . PHP_EOL;
+    echo implode(PHP_EOL, $output);
+    exit($code);
+}


### PR DESCRIPTION
This PR resolves the compilation issues when running 2.4.4 on PHP 8.1.

PHP 8.1 is the only supported version for Magento 2.4.4. 

https://github.com/magento/magento2/issues/35292#issuecomment-1252730116

<img width="891" alt="image" src="https://github.com/user-attachments/assets/56bd8580-78e5-4655-83b5-92bf344e3f35">



