### PR TITLE
Fix GraphQL API by pinning webonyx/graphql-php version to <15.31.0

### DIFF
--- a/magento/Dockerfile-2.4
+++ b/magento/Dockerfile-2.4
@@ -64,7 +64,6 @@ RUN set -e; \
     mkdir -p extensions && \
     composer config repositories.dev-extensions path extensions/* && \
     composer require --dev phpstan/phpstan bitexpert/phpstan-magento phpstan/extension-installer && \
-    composer require "webonyx/graphql-php:^15.0 <15.31.0" && \
     php scripts/apply-2.4-patches.php && \
     rm scripts/apply-2.4-patches.php && \
     rm scripts/downgrade-monolog.php && \

--- a/magento/Dockerfile-2.4
+++ b/magento/Dockerfile-2.4
@@ -64,6 +64,7 @@ RUN set -e; \
     mkdir -p extensions && \
     composer config repositories.dev-extensions path extensions/* && \
     composer require --dev phpstan/phpstan bitexpert/phpstan-magento phpstan/extension-installer && \
+    composer require "webonyx/graphql-php:^15.0 <15.31.0" && \
     php scripts/apply-2.4-patches.php && \
     rm scripts/apply-2.4-patches.php && \
     rm scripts/downgrade-monolog.php && \

--- a/magento/scripts/apply-2.4-patches.php
+++ b/magento/scripts/apply-2.4-patches.php
@@ -7,6 +7,9 @@ $is242 = substr($version, 0, 5) == '2.4.2';
 $is243 = substr($version, 0, 5) == '2.4.3';
 $is244 = substr($version, 0, 5) == '2.4.4';
 $is245 = substr($version, 0, 5) == '2.4.5';
+$is246 = substr($version, 0, 5) == '2.4.6';
+$is247 = substr($version, 0, 5) == '2.4.7';
+$is248 = substr($version, 0, 5) == '2.4.8';
 $isP1 = substr($version, 6, 8) == 'p1';
 $isP2 = substr($version, 6, 8) == 'p2';
 
@@ -58,6 +61,10 @@ if ($is245) {
 
 if ($is240 && !$isP1 && !$isP2) {
     apply('bundle-2684_dotmailer_integration_tests-2020-08-04-04-31-22.patch');
+}
+
+if ($is246 || $is247 || $is248) {
+    exec('composer require "webonyx/graphql-php:^15.0 <15.31.0"');
 }
 
 apply('cors.patch');


### PR DESCRIPTION
Applied the same patch as Mage OS: https://github.com/mage-os/mageos-magento2/pull/211, related:

- https://github.com/webonyx/graphql-php/issues/1874
- https://github.com/magento/magento2/issues/40591

Can be removed when it's fixed in the next version.