### PR TITLE
Fix with-replacements workflow testing the wrong image

### DIFF
--- a/.github/workflows/magento-with-replacements.yml
+++ b/.github/workflows/magento-with-replacements.yml
@@ -60,7 +60,7 @@ jobs:
         -p 80:80
         -e ENABLE_VARNISH=${{ steps.varnish.outputs.enabled }}
         -e URL=http://magento.test/
-        michielgerritsen/magento-project-community-edition:${{ matrix.cfg.PHP_VERSION }}-magento${{ matrix.cfg.MAGENTO_VERSION }}
+        michielgerritsen/magento-project-community-edition:${{ matrix.cfg.PHP_VERSION }}-magento${{ matrix.cfg.MAGENTO_VERSION }}-with-replacements
 
     - name: Verify webserver is accessible
       run: |


### PR DESCRIPTION
The docker run step in the with-replacements workflow referenced the image tag without the -with-replacements suffix, a tag this workflow never builds, so Docker silently pulled the plain 2.4.6 image from Docker Hub and every test ran against that stale image instead of the one just built. The new CORS tests exposed it: the pulled image predates ENABLE_CORS, so the headers were missing. One-line fix appending the suffix to the docker run tag. The other two workflows use the computed tag output and are not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NJY76wPZ1eNYMs447yiM3